### PR TITLE
refactor(project): migrate to java 17, spring 6, and jakarta namespaces

### DIFF
--- a/jweatherhistory-gui/pom.xml
+++ b/jweatherhistory-gui/pom.xml
@@ -37,13 +37,12 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.inject</groupId>
-			<artifactId>javax.inject</artifactId>
-			<version>1</version>
+			<groupId>jakarta.inject</groupId>
+			<artifactId>jakarta.inject-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
+			<groupId>jakarta.annotation</groupId>
+			<artifactId>jakarta.annotation-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/jweatherhistory-gui/src/main/java/za/co/johanmynhardt/jweatherhistory/gui/JWeatherHistoryUI.java
+++ b/jweatherhistory-gui/src/main/java/za/co/johanmynhardt/jweatherhistory/gui/JWeatherHistoryUI.java
@@ -16,8 +16,8 @@ import com.jgoodies.looks.plastic.theme.LightGray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import javax.swing.*;
 
 import java.io.BufferedOutputStream;

--- a/jweatherhistory-gui/src/main/java/za/co/johanmynhardt/jweatherhistory/gui/MainFrame.java
+++ b/jweatherhistory-gui/src/main/java/za/co/johanmynhardt/jweatherhistory/gui/MainFrame.java
@@ -10,8 +10,8 @@ import org.springframework.context.ApplicationContextAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
 import javax.swing.*;
 import javax.swing.event.ListDataListener;
 import javax.swing.table.AbstractTableModel;

--- a/jweatherhistory-gui/src/main/java/za/co/johanmynhardt/jweatherhistory/gui/WeatherEntryEditor.java
+++ b/jweatherhistory-gui/src/main/java/za/co/johanmynhardt/jweatherhistory/gui/WeatherEntryEditor.java
@@ -5,8 +5,8 @@ import com.google.common.eventbus.EventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
 import javax.swing.*;
 
 import java.awt.*;

--- a/jweatherhistory-impl/pom.xml
+++ b/jweatherhistory-impl/pom.xml
@@ -40,13 +40,12 @@
 			<artifactId>spring-context</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.inject</groupId>
-			<artifactId>javax.inject</artifactId>
-			<version>1</version>
+			<groupId>jakarta.inject</groupId>
+			<artifactId>jakarta.inject-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
+			<groupId>jakarta.annotation</groupId>
+			<artifactId>jakarta.annotation-api</artifactId>
 		</dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/jweatherhistory-impl/src/main/java/za/co/johanmynhardt/jweatherhistory/impl/data/JsonDataSerializer.java
+++ b/jweatherhistory-impl/src/main/java/za/co/johanmynhardt/jweatherhistory/impl/data/JsonDataSerializer.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/jweatherhistory-impl/src/main/java/za/co/johanmynhardt/jweatherhistory/impl/service/WeatherHistoryService.java
+++ b/jweatherhistory-impl/src/main/java/za/co/johanmynhardt/jweatherhistory/impl/service/WeatherHistoryService.java
@@ -11,8 +11,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSetMetaData;

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
         <!-- Dependency Versions (Java 8 Compatible) -->
@@ -27,7 +27,7 @@
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.13</logback.version>
         <guava.version>32.1.3-jre</guava.version>
-        <spring.version>5.3.39</spring.version>
+        <spring.version>6.1.5</spring.version>
         <jackson.version>2.18.6</jackson.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <jgoodies-common.version>1.8.1</jgoodies-common.version>
@@ -146,9 +146,14 @@
                 <version>${jgoodies-looks.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>1.3.2</version>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>2.1.1</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>2.0.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
- update maven compiler source and target to `17`
- upgrade spring framework version to `6.1.5`
- replace `javax.inject` and `javax.annotation` dependencies with `jakarta` equivalents
- update java imports to use `jakarta.annotation` and `jakarta.inject` packages